### PR TITLE
Add release_id input and update release processing logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ This is a fairly simple action, for more details see [src/index.js](src/index.js
 | `vt_api_key`      | **Required**                  | VirusTotal API Key \*                                  |
 | `file_globs`      | -                             | File Globs to Process \*                               |
 | `rate_limit`      | `4`                           | API Calls Per Minute \*                                |
+| `release_id`      | `''`                          | Release ID to Process                                  |
 | `update_release`  | `true`                        | Update the [Release Notes](#Release-Notes)             |
 | `release_heading` | _[see below](#Release-Notes)_ | Release Notes Heading [⤵️](#Release-Notes)             |
 | `collapsed`       | `false`                       | Show Links Collapsed. [⤵️](#Release-Notes)             |
@@ -77,6 +78,10 @@ This is a fairly simple action, for more details see [src/index.js](src/index.js
 
 **file_globs:** If provided, will process matching files instead of release assets.  
 For glob pattern, see [examples](#examples) and the [docs](https://github.com/actions/toolkit/tree/main/packages/glob#patterns).
+
+**release_id:** If provided, will process the corresponding release.
+The release ID can be generated from a previous step.
+By providing a release ID, this action does not need to run on a release event to process a release.
 
 **rate_limit:** Rate limit for file uploads. Set to `0` to disable if you know what you are doing.
 

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: "API Calls Per Minute"
     required: false
     default: "4"
+  release_id:
+    description: "Release ID to process"
+    required: false
+    default: ""
   update_release:
     description: "Update Release Notes"
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -44614,15 +44614,22 @@ async function processVt(inputs, name, filePath) {
  */
 async function getRelease(octokit, release_id) {
     const target_release_id = release_id || github.context.payload.release?.id
-    if (!target_release_id) {
-        return
-    }
+    if (!target_release_id) return
+
     core.info(`Getting Release: \u001b[32m${target_release_id}`)
-    const release = await octokit.rest.repos.getRelease({
+
+    let release = await octokit.rest.repos.getRelease({
         ...github.context.repo,
         release_id: target_release_id,
     })
-    return release.data
+    if (release) return release.data
+
+    // try getting by tag name
+    release = await octokit.rest.repos.getReleaseByTag({
+        ...github.context.repo,
+        tag: target_release_id,
+    })
+    return release?.data
 }
 
 /**

--- a/dist/index.js
+++ b/dist/index.js
@@ -44438,23 +44438,21 @@ const vtUpload = __nccwpck_require__(9431)
                 }
             }
 
-            body += `\n\n`
+            body += `\n`
             if (inputs.heading) {
-                body += `${inputs.heading}\n\n`
+                body += `\n${inputs.heading}\n`
             }
             if (inputs.collapsed) {
-                body += `\n\n<details><summary>Click Here to Show Scan Results</summary>\n\n`
+                body += `\n<details><summary>Click Here to Show Scan Results</summary>\n`
             }
             // const collapsed = inputs.collapsed ? '' : ' open'
             // body += `\n\n<details${collapsed}><summary>${inputs.heading}</summary>\n\n`
             for (const result of existing_results_list) {
-                body += `- [${result.name}](${result.link})\n`
+                body += `\n- [${result.name}](${result.link})`
             }
             if (inputs.collapsed) {
-                body += '\n\n</details>\n\n'
-            } else {
-                body += `\n\n`
-            }
+                body += '\n\n</details>'
+            } 
 
             console.log(`\n${body}\n`)
             await octokit.rest.repos.updateRelease({

--- a/dist/index.js
+++ b/dist/index.js
@@ -44452,7 +44452,7 @@ const vtUpload = __nccwpck_require__(9431)
             }
             if (inputs.collapsed) {
                 body += '\n\n</details>'
-            } 
+            }
 
             console.log(`\n${body}\n`)
             await octokit.rest.repos.updateRelease({

--- a/src/index.js
+++ b/src/index.js
@@ -262,15 +262,22 @@ async function processVt(inputs, name, filePath) {
  */
 async function getRelease(octokit, release_id) {
     const target_release_id = release_id || github.context.payload.release?.id
-    if (!target_release_id) {
-        return
-    }
+    if (!target_release_id) return
+
     core.info(`Getting Release: \u001b[32m${target_release_id}`)
-    const release = await octokit.rest.repos.getRelease({
+
+    let release = await octokit.rest.repos.getRelease({
         ...github.context.repo,
         release_id: target_release_id,
     })
-    return release.data
+    if (release) return release.data
+
+    // try getting by tag name
+    release = await octokit.rest.repos.getReleaseByTag({
+        ...github.context.repo,
+        tag: target_release_id,
+    })
+    return release?.data
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ const vtUpload = require('./vt')
 
         // Set Variables
         const octokit = github.getOctokit(inputs.token)
-        const release = await getRelease(octokit)
+        const release = await getRelease(octokit, inputs.release_id)
         const limiter = new RateLimiter({
             tokensPerInterval: inputs.rate,
             interval: 'minute',
@@ -48,6 +48,44 @@ const vtUpload = require('./vt')
             core.startGroup(`Updating Release ${release.id}`)
             let body = release.body
 
+            let existing_results = ''
+            if (inputs.heading) {
+                const heading_index = body.indexOf(inputs.heading)
+                if (heading_index > -1) {
+                    existing_results = body.slice(heading_index).trim()
+                    body = body.slice(0, heading_index).trim()
+                }
+            }
+
+            let existing_results_list = []
+            if (existing_results) {
+                const matches = [...existing_results.matchAll(/- \[(.*?)\]\((.*?)\)/g)]
+                existing_results_list = matches.map((match) => ({
+                    name: match[1],
+                    link: match[2],
+                }))
+            }
+
+            for (const result of results) {
+                let name = result.name
+                if (inputs.name === 'id') {
+                    name = result.id
+                    // } else if (inputs.name === 'hash') {
+                    //     name = 'TODO: ADD HASH HERE'
+                }
+                console.log(`name: ${name}`)
+                if (inputs.name) {
+                    // remove existing entry and append new one
+                    existing_results_list = existing_results_list.filter(
+                        (r) => r.name !== name
+                    )
+                    existing_results_list.push({
+                        name,
+                        link: result.link,
+                    })
+                }
+            }
+
             body += `\n\n`
             if (inputs.heading) {
                 body += `${inputs.heading}\n\n`
@@ -57,15 +95,8 @@ const vtUpload = require('./vt')
             }
             // const collapsed = inputs.collapsed ? '' : ' open'
             // body += `\n\n<details${collapsed}><summary>${inputs.heading}</summary>\n\n`
-            for (const result of results) {
-                let name = result.name
-                if (inputs.name === 'id') {
-                    name = result.id
-                    // } else if (inputs.name === 'hash') {
-                    //     name = 'TODO: ADD HASH HERE'
-                }
-                console.log(`name: ${name}`)
-                if (inputs.name) body += `\n- [${name}](${result.link})`
+            for (const result of existing_results_list) {
+                body += `- [${result.name}](${result.link})\n`
             }
             if (inputs.collapsed) {
                 body += '\n\n</details>\n\n'
@@ -228,16 +259,18 @@ async function processVt(inputs, name, filePath) {
 /**
  * Get Release
  * @param {InstanceType<typeof github.GitHub>} octokit
+ * @param {String} release_id
  * @return {Promise<InstanceType<typeof github.GitHub>|Undefined>}
  */
-async function getRelease(octokit) {
-    if (!github.context.payload.release?.id) {
+async function getRelease(octokit, release_id) {
+    const target_release_id = release_id || github.context.payload.release?.id
+    if (!target_release_id) {
         return
     }
-    core.info(`Getting Release: \u001b[32m${github.context.payload.release.id}`)
+    core.info(`Getting Release: \u001b[32m${target_release_id}`)
     const release = await octokit.rest.repos.getRelease({
         ...github.context.repo,
-        release_id: github.context.payload.release.id,
+        release_id: target_release_id,
     })
     return release.data
 }
@@ -295,6 +328,7 @@ async function addSummary(inputs, results, output) {
  * @property {String[]} files
  * @property {Number} rate
  * @property {Boolean} update
+ * @property {String} release_id
  * @property {Boolean} collapsed
  * @property {String} name
  * @property {String} heading
@@ -308,6 +342,7 @@ function getInputs() {
         files: core.getInput('file_globs').split('\n').filter(Boolean),
         rate: Number.parseInt(core.getInput('rate_limit', { required: true })),
         update: core.getBooleanInput('update_release'),
+        release_id: core.getInput('release_id'),
         collapsed: core.getBooleanInput('collapsed'),
         name: core.getInput('file_name').toLowerCase(),
         heading: core.getInput('release_heading'),

--- a/src/index.js
+++ b/src/index.js
@@ -86,22 +86,20 @@ const vtUpload = require('./vt')
                 }
             }
 
-            body += `\n\n`
+            body += `\n`
             if (inputs.heading) {
-                body += `${inputs.heading}\n\n`
+                body += `\n${inputs.heading}\n`
             }
             if (inputs.collapsed) {
-                body += `\n\n<details><summary>Click Here to Show Scan Results</summary>\n\n`
+                body += `\n<details><summary>Click Here to Show Scan Results</summary>\n`
             }
             // const collapsed = inputs.collapsed ? '' : ' open'
             // body += `\n\n<details${collapsed}><summary>${inputs.heading}</summary>\n\n`
             for (const result of existing_results_list) {
-                body += `- [${result.name}](${result.link})\n`
+                body += `\n- [${result.name}](${result.link})`
             }
             if (inputs.collapsed) {
-                body += '\n\n</details>\n\n'
-            } else {
-                body += `\n\n`
+                body += '\n\n</details>'
             }
 
             console.log(`\n${body}\n`)


### PR DESCRIPTION
Introduce a `release_id` input to allow processing of a specific release without relying on a release event. Update the release retrieval logic to accommodate this new input. Adjust the handling of existing results in the release notes.