### PR TITLE
Get all assets in a release

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -44514,11 +44514,13 @@ async function processRelease(inputs, limiter, octokit, release) {
     // Get Assets
     let allAssets = []
     let page = 0
+    const { data } = await octokit.rest.rateLimit.get()
+    const ghLimiter = new RateLimiter({
+        tokensPerInterval: data.resources.core.limit,
+        interval: 'hour',
+    })
     while (true) {
-        if (inputs.rate) {
-            const remainingRequests = await limiter.removeTokens(1)
-            console.log('remainingRequests:', remainingRequests)
-        }
+        await ghLimiter.removeTokens(1)
         const assets = await octokit.rest.repos.listReleaseAssets({
             ...github.context.repo,
             release_id: release.id,

--- a/src/index.js
+++ b/src/index.js
@@ -162,11 +162,13 @@ async function processRelease(inputs, limiter, octokit, release) {
     // Get Assets
     let allAssets = []
     let page = 0
+    const { data } = await octokit.rest.rateLimit.get()
+    const ghLimiter = new RateLimiter({
+        tokensPerInterval: data.resources.core.limit,
+        interval: 'hour',
+    })
     while (true) {
-        if (inputs.rate) {
-            const remainingRequests = await limiter.removeTokens(1)
-            console.log('remainingRequests:', remainingRequests)
-        }
+        await ghLimiter.removeTokens(1)
         const assets = await octokit.rest.repos.listReleaseAssets({
             ...github.context.repo,
             release_id: release.id,

--- a/src/index.js
+++ b/src/index.js
@@ -160,17 +160,21 @@ async function processRelease(inputs, limiter, octokit, release) {
     core.endGroup() // Release
 
     // Get Assets
-    let all_assets = []
+    let allAssets = []
     let page = 0
     while (true) {
+        if (inputs.rate) {
+            const remainingRequests = await limiter.removeTokens(1)
+            console.log('remainingRequests:', remainingRequests)
+        }
         const assets = await octokit.rest.repos.listReleaseAssets({
             ...github.context.repo,
             release_id: release.id,
-            per_page: 10,
+            per_page: 100,
             page: ++page,
         })
         if (!assets.data.length) break
-        all_assets = all_assets.concat(assets.data)
+        allAssets = all_assets.concat(assets.data)
     }
     if (!all_assets.length) {
         throw new Error(`No Assets Found for Release: ${release.id}`)
@@ -184,12 +188,12 @@ async function processRelease(inputs, limiter, octokit, release) {
         fs.mkdirSync(assetsPath)
     }
 
-    console.log(all_assets)
+    console.log(allAssets)
     core.endGroup() // Assets
 
     // Process Assets
     const results = []
-    for (const asset of all_assets) {
+    for (const asset of allAssets) {
         core.startGroup(`Processing: \u001b[36m${asset.name}`)
         if (inputs.rate) {
             const remainingRequests = await limiter.removeTokens(1)

--- a/src/index.js
+++ b/src/index.js
@@ -160,12 +160,19 @@ async function processRelease(inputs, limiter, octokit, release) {
     core.endGroup() // Release
 
     // Get Assets
-    const assets = await octokit.rest.repos.listReleaseAssets({
-        ...github.context.repo,
-        release_id: release.id,
-    })
-    if (!assets?.data?.length) {
-        console.log('assets:', assets)
+    let all_assets = []
+    let page = 0
+    while (true) {
+        const assets = await octokit.rest.repos.listReleaseAssets({
+            ...github.context.repo,
+            release_id: release.id,
+            per_page: 10,
+            page: ++page,
+        })
+        if (!assets.data.length) break
+        all_assets = all_assets.concat(assets.data)
+    }
+    if (!all_assets.length) {
         throw new Error(`No Assets Found for Release: ${release.id}`)
     }
 
@@ -177,12 +184,12 @@ async function processRelease(inputs, limiter, octokit, release) {
         fs.mkdirSync(assetsPath)
     }
 
-    console.log(assets.data)
+    console.log(all_assets)
     core.endGroup() // Assets
 
     // Process Assets
     const results = []
-    for (const asset of assets.data) {
+    for (const asset of all_assets) {
         core.startGroup(`Processing: \u001b[36m${asset.name}`)
         if (inputs.rate) {
             const remainingRequests = await limiter.removeTokens(1)


### PR DESCRIPTION
A single request can at most get 30 assets.
In this PR, get all assets in a release.