### PR TITLE
Fix variable name consistency in processRelease function

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -44528,9 +44528,9 @@ async function processRelease(inputs, limiter, octokit, release) {
             page: ++page,
         })
         if (!assets.data.length) break
-        allAssets = all_assets.concat(assets.data)
+        allAssets = allAssets.concat(assets.data)
     }
-    if (!all_assets.length) {
+    if (!allAssets.length) {
         throw new Error(`No Assets Found for Release: ${release.id}`)
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -176,9 +176,9 @@ async function processRelease(inputs, limiter, octokit, release) {
             page: ++page,
         })
         if (!assets.data.length) break
-        allAssets = all_assets.concat(assets.data)
+        allAssets = allAssets.concat(assets.data)
     }
-    if (!all_assets.length) {
+    if (!allAssets.length) {
         throw new Error(`No Assets Found for Release: ${release.id}`)
     }
 


### PR DESCRIPTION
Ensure consistent use of the variable name `allAssets` throughout the `processRelease` function.