### PR TITLE
Add Retry for 409

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,6 +18,7 @@ jobs:
 
     permissions:
       pull-requests: write
+      checks: write
 
     steps:
       - name: "Checkout"

--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ Any feedback is helpful during this phase of development.
 | `rate_limit`      | `4`                           | API Calls Per Minute [⤵️](#rate_limit)             |
 | `release_id`      | -                             | Release ID to Process [⤵️](#release_id)            |
 | `sha256`          | `false`                       | Calculate File SHA256 [⤵️](#sha256)                |
+| `fail`            | `any`                         | Fail mode: [`any`, `all`, `none`] [⤵️](#fail)      |
+| `retries`         | `3`                           | Number of Retries for 409 [⤵️](#retries)           |
+| `cooldown`        | `30`                          | Number of Retries for 409 [⤵️](#cooldown)          |
+| `multiplier`      | `2`                           | Number of Retries for 409 [⤵️](#multiplier)        |
 | `update_release`  | `true`                        | Update the [Release Notes](#Release-Notes)         |
 | `release_heading` | _[see below](#Release-Notes)_ | Release Notes Heading [⤵️](#release_heading)       |
 | `collapsed`       | `false`                       | Show Links Collapsed. [⤵️](#collapsed)             |
@@ -124,7 +128,28 @@ By providing a release ID, this action does not need to run on a release event t
 
 #### sha256
 
+The SHA256 hash is not returned by the API; however, can be optionally calculated for additional overhead.
 If enabled this will calculate the file's SHA256 hash, and include it in the output.
+
+#### fail
+
+Fail mode: [`any`, `all`, `none`]
+
+- `any`: Fail the job if there are any failures.
+- `all`: Fail the job only if all files fail.
+- `none`: Don't fail for any failures.
+
+#### retries
+
+Number of Retries on a 409 error.
+
+#### cooldown
+
+Retry cooldown in seconds.
+
+#### multiplier
+
+Cooldown multiplier per retry.
 
 #### summary
 
@@ -484,12 +509,12 @@ For more information, see the CSSNR [SUPPORT.md](https://github.com/cssnr/.githu
 
 # Contributing
 
+If you would like to submit a PR, please review the [CONTRIBUTING.md](#contributing-ov-file).
+
 Please consider making a donation to support the development of this project
 and [additional](https://cssnr.com/) open source projects.
 
 [![Ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/cssnr)
-
-If you would like to submit a PR, please review the [CONTRIBUTING.md](#contributing-ov-file).
 
 Additionally, you can support other GitHub Actions I have published:
 
@@ -543,4 +568,4 @@ Note: The `docker-test-action` builds, runs and pushes images to [GitHub Contain
 
 </details>
 
-For a full list of current projects visit: [https://cssnr.github.io/](https://cssnr.github.io/)
+For a full list of current projects to support visit: [https://cssnr.github.io/](https://cssnr.github.io/)

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,18 @@ inputs:
   sha256:
     description: "Calculate sha256 Hash"
     default: "false"
+  fail:
+    description: "Fail mode: any, all, none"
+    default: "any"
+  retries:
+    description: "Number of Retries for 409"
+    default: "3"
+  cooldown:
+    description: "Retry cooldown in seconds"
+    default: "30"
+  multiplier:
+    description: "Cooldown multiplier per retry"
+    default: "2"
   update_release:
     description: "Update Release Notes"
     default: "true"

--- a/dist/index.js
+++ b/dist/index.js
@@ -37032,9 +37032,17 @@ class VTClient {
     #apiKey
     #sha256 = false
     #limiter = null
+    fail
+    retries
+    cooldown
+    multiplier
     constructor(inputs) {
         this.#apiKey = inputs.key
         this.#sha256 = inputs.sha256
+        this.fail = inputs.fail
+        this.retries = inputs.retries
+        this.cooldown = inputs.cooldown / inputs.multiplier
+        this.multiplier = inputs.multiplier
         if (inputs.rate) {
             this.#limiter = new RateLimiter({
                 tokensPerInterval: inputs.rate,
@@ -37082,13 +37090,17 @@ class VTClient {
      * Process a file
      * @param {String} name
      * @param {String} filePath
-     * @return {Promise<{name, link: string, id}>}
+     * @return {Promise<{Object}>}
      */
     async #process(name, filePath) {
         if (this.#limiter) {
             const remainingRequests = await this.#limiter.removeTokens(1)
             console.log('remainingRequests:', remainingRequests)
         }
+        // const error = new Error('Its Broken')
+        // error.status = 409
+        // throw error
+        // return { name: '', link: '', id: 1 }
         const response = await this.#upload(filePath)
         console.log('response.data.id:', response.data.id)
         const link = `https://www.virustotal.com/gui/file-analysis/${response.data.id}`
@@ -37125,11 +37137,50 @@ class VTClient {
         console.log(files)
         core.endGroup() // Files
         const results = []
-        for (const file of files) {
+        let failed = 0
+
+        while (files.length > 0) {
+            const file = files.shift()
             const name = path.basename(file)
             core.startGroup(`Processing: \u001b[36m${name}`)
-            results.push(await this.#process(name, file))
-            core.endGroup() // Processing
+            try {
+                const result = await this.#process(name, file)
+                results.push(result)
+                core.endGroup() // Processing
+            } catch (e) {
+                // NOTE: Need to use a limiter with ability to add tokens...
+
+                core.startGroup(`Error: ${e.status}`)
+                // console.log('e:', e)
+                console.log('e.message:', e.message)
+                console.log('e.status:', e.status) // number?
+                console.log('e.code:', e.code) // string?
+                console.log('e.response?.status:', e.response?.status)
+                console.log('e.response?.statusText:', e.response?.statusText)
+                console.log('e.response?.headers:', e.response?.headers)
+                console.log('e.response?.data:', e.response?.data)
+                core.endGroup() // Error
+
+                if (e.status === 409 && this.retries > 0) {
+                    this.retries--
+                    files.unshift(file) // NOTE: Consider adding to back of stack...
+                    console.log('this.retries:', this.retries)
+                    this.cooldown = this.cooldown * this.multiplier
+                    console.log('this.cooldown:', this.cooldown)
+                    await new Promise((r) => setTimeout(r, this.cooldown * 1000))
+                    continue
+                }
+
+                failed++
+                if (this.fail === 'any') {
+                    console.log(`\u001b[35m Throw on FAIL: [any], all, none`)
+                    throw new Error(e)
+                }
+            }
+            if (this.fail === 'all' && !results.length) {
+                console.log(`\u001b[35m Throw on FAIL: any, [all], none`)
+                throw new Error('All files failed and fail mode set to all.')
+            }
         }
         return results
     }
@@ -44497,6 +44548,11 @@ const VTClient = __nccwpck_require__(9431)
         const release = await getRelease(octokit, inputs.release_id)
         const client = new VTClient(inputs)
 
+        if (['any', 'all', 'none'].includes(inputs.fail)) {
+            core.warning(`Invalid fail mode: ${inputs.fail} - Using: any`)
+            inputs.fail = 'any'
+        }
+
         core.endGroup() // Inputs
 
         // Process
@@ -44703,6 +44759,10 @@ async function addSummary(inputs, results, output) {
  * @property {String} key
  * @property {String[]} files
  * @property {Number} rate
+ * @property {String} fail
+ * @property {Number} retries
+ * @property {Number} cooldown
+ * @property {Number} multiplier
  * @property {Boolean} update
  * @property {String} release_id
  * @property {Boolean} sha256
@@ -44718,9 +44778,13 @@ function getInputs() {
         key: core.getInput('vt_api_key', { required: true }),
         files: core.getInput('file_globs').split('\n').filter(Boolean),
         rate: Number.parseInt(core.getInput('rate_limit', { required: true })),
-        update: core.getBooleanInput('update_release'),
         release_id: core.getInput('release_id'),
         sha256: core.getBooleanInput('sha256'),
+        fail: core.getInput('fail').toLowerCase(),
+        retries: Number.parseInt(core.getInput('retries') || 0),
+        cooldown: Number.parseInt(core.getInput('cooldown') || 0),
+        multiplier: Number.parseInt(core.getInput('multiplier') || 0),
+        update: core.getBooleanInput('update_release'),
         collapsed: core.getBooleanInput('collapsed'),
         name: core.getInput('file_name').toLowerCase(),
         heading: core.getInput('release_heading'),

--- a/dist/index.js
+++ b/dist/index.js
@@ -37137,7 +37137,7 @@ class VTClient {
         console.log(files)
         core.endGroup() // Files
         const results = []
-        let failed = 0
+        // let failed = 0
 
         while (files.length > 0) {
             const file = files.shift()
@@ -37171,7 +37171,7 @@ class VTClient {
                     continue
                 }
 
-                failed++
+                // failed++
                 if (this.fail === 'any') {
                     console.log(`\u001b[35m Throw on FAIL: [any], all, none`)
                     throw new Error(e)

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,11 @@ const VTClient = require('./vt.js')
         const release = await getRelease(octokit, inputs.release_id)
         const client = new VTClient(inputs)
 
+        if (['any', 'all', 'none'].includes(inputs.fail)) {
+            core.warning(`Invalid fail mode: ${inputs.fail} - Using: any`)
+            inputs.fail = 'any'
+        }
+
         core.endGroup() // Inputs
 
         // Process
@@ -224,6 +229,10 @@ async function addSummary(inputs, results, output) {
  * @property {String} key
  * @property {String[]} files
  * @property {Number} rate
+ * @property {String} fail
+ * @property {Number} retries
+ * @property {Number} cooldown
+ * @property {Number} multiplier
  * @property {Boolean} update
  * @property {String} release_id
  * @property {Boolean} sha256
@@ -239,9 +248,13 @@ function getInputs() {
         key: core.getInput('vt_api_key', { required: true }),
         files: core.getInput('file_globs').split('\n').filter(Boolean),
         rate: Number.parseInt(core.getInput('rate_limit', { required: true })),
-        update: core.getBooleanInput('update_release'),
         release_id: core.getInput('release_id'),
         sha256: core.getBooleanInput('sha256'),
+        fail: core.getInput('fail').toLowerCase(),
+        retries: Number.parseInt(core.getInput('retries') || 0),
+        cooldown: Number.parseInt(core.getInput('cooldown') || 0),
+        multiplier: Number.parseInt(core.getInput('multiplier') || 0),
+        update: core.getBooleanInput('update_release'),
         collapsed: core.getBooleanInput('collapsed'),
         name: core.getInput('file_name').toLowerCase(),
         heading: core.getInput('release_heading'),

--- a/src/vt.js
+++ b/src/vt.js
@@ -16,9 +16,17 @@ class VTClient {
     #apiKey
     #sha256 = false
     #limiter = null
+    fail
+    retries
+    cooldown
+    multiplier
     constructor(inputs) {
         this.#apiKey = inputs.key
         this.#sha256 = inputs.sha256
+        this.fail = inputs.fail
+        this.retries = inputs.retries
+        this.cooldown = inputs.cooldown / inputs.multiplier
+        this.multiplier = inputs.multiplier
         if (inputs.rate) {
             this.#limiter = new RateLimiter({
                 tokensPerInterval: inputs.rate,
@@ -66,13 +74,17 @@ class VTClient {
      * Process a file
      * @param {String} name
      * @param {String} filePath
-     * @return {Promise<{name, link: string, id}>}
+     * @return {Promise<{Object}>}
      */
     async #process(name, filePath) {
         if (this.#limiter) {
             const remainingRequests = await this.#limiter.removeTokens(1)
             console.log('remainingRequests:', remainingRequests)
         }
+        // const error = new Error('Its Broken')
+        // error.status = 409
+        // throw error
+        // return { name: '', link: '', id: 1 }
         const response = await this.#upload(filePath)
         console.log('response.data.id:', response.data.id)
         const link = `https://www.virustotal.com/gui/file-analysis/${response.data.id}`
@@ -109,11 +121,50 @@ class VTClient {
         console.log(files)
         core.endGroup() // Files
         const results = []
-        for (const file of files) {
+        let failed = 0
+
+        while (files.length > 0) {
+            const file = files.shift()
             const name = path.basename(file)
             core.startGroup(`Processing: \u001b[36m${name}`)
-            results.push(await this.#process(name, file))
-            core.endGroup() // Processing
+            try {
+                const result = await this.#process(name, file)
+                results.push(result)
+                core.endGroup() // Processing
+            } catch (e) {
+                // NOTE: Need to use a limiter with ability to add tokens...
+
+                core.startGroup(`Error: ${e.status}`)
+                // console.log('e:', e)
+                console.log('e.message:', e.message)
+                console.log('e.status:', e.status) // number?
+                console.log('e.code:', e.code) // string?
+                console.log('e.response?.status:', e.response?.status)
+                console.log('e.response?.statusText:', e.response?.statusText)
+                console.log('e.response?.headers:', e.response?.headers)
+                console.log('e.response?.data:', e.response?.data)
+                core.endGroup() // Error
+
+                if (e.status === 409 && this.retries > 0) {
+                    this.retries--
+                    files.unshift(file) // NOTE: Consider adding to back of stack...
+                    console.log('this.retries:', this.retries)
+                    this.cooldown = this.cooldown * this.multiplier
+                    console.log('this.cooldown:', this.cooldown)
+                    await new Promise((r) => setTimeout(r, this.cooldown * 1000))
+                    continue
+                }
+
+                failed++
+                if (this.fail === 'any') {
+                    console.log(`\u001b[35m Throw on FAIL: [any], all, none`)
+                    throw new Error(e)
+                }
+            }
+            if (this.fail === 'all' && !results.length) {
+                console.log(`\u001b[35m Throw on FAIL: any, [all], none`)
+                throw new Error('All files failed and fail mode set to all.')
+            }
         }
         return results
     }

--- a/src/vt.js
+++ b/src/vt.js
@@ -121,7 +121,7 @@ class VTClient {
         console.log(files)
         core.endGroup() // Files
         const results = []
-        let failed = 0
+        // let failed = 0
 
         while (files.length > 0) {
             const file = files.shift()
@@ -155,7 +155,7 @@ class VTClient {
                     continue
                 }
 
-                failed++
+                // failed++
                 if (this.fail === 'any') {
                     console.log(`\u001b[35m Throw on FAIL: [any], all, none`)
                     throw new Error(e)


### PR DESCRIPTION
# Overview

For #30

- Add 3 new inputs for 409 Retry
  - `retries`
  - `cooldown`
  - `multiplier`
- Add new input for Fail Mode
  - `any` - Fail the job if there are any failures.
  - `all` - Fail the job only if all files fail.
  - `none` - Don't fail for any failures.

## Checklist
<!-- Do NOT remove tasks and append any custom tasks -->
- [ ] Verify the Required Checks are Passing
- [ ] Document changes in the [README.md](../blob/master/README.md) (for new features)
- [ ] Confirm Retry Inputs and Defaults
- [ ] Confirm Failure Mode Types